### PR TITLE
Seperated feature files into 2 files.

### DIFF
--- a/authentication.feature
+++ b/authentication.feature
@@ -1,4 +1,4 @@
-Feature: Authorization
+Feature: Authentication
 	In order to perform operations against the api
 	as a developer consuming the sdk
 	I need to be able to authenticate

--- a/clientcredentials-collections.feature
+++ b/clientcredentials-collections.feature
@@ -1,0 +1,10 @@
+Feature: Collections with Client Credentials
+  In order to find what I want by collection
+  as a developer wanting to use Getty Images assets
+  I must provide Resource Owner Credentials
+
+Scenario: Get Collections is not authorized
+  Given I have an apikey
+    And an apisecret
+  When I retrieve collections
+  Then I recieve an error stating "Your access token does not authorize access to this resource."

--- a/clientcredentials-countries.feature
+++ b/clientcredentials-countries.feature
@@ -1,9 +1,9 @@
-Feature: Countries
+Feature: Countries with Client Credentials
   In order to supply the right country codes to api calls
   as a developer that wants to programatically get assets by country
   I need be able to get the list of countries that are available
 
-Scenario: Get Countries with Client Credentials
+Scenario: Get Countries succeeds
   Given I have an apikey
     And an apisecret
   When I retrieve countries

--- a/clientcredentials-events.feature
+++ b/clientcredentials-events.feature
@@ -1,23 +1,22 @@
-Feature: Event Details
+Feature: Event details with client credentials
   To create a rockin website with sweet images based on events i'm interested in
-  As a developer that wants to get some image details
+  As a developer that wants to get some image details with Client Credentials
   I'd need to be able to get events so I can use them to refine my search queries
 
-Scenario: Resource Owner Credentials
+#Scenario: Client Credentials
+Scenario: Specify a single event id for event detail request
 	Given I have an apikey
 	And an apisecret
-	And a username
-	And a password
 	And I have an event id I want details on
 	When I retrieve event details
 	Then I get a response back that has my event
 
-Scenario: Client Credentials
+Scenario: Specify multiple ids in batch event detail request
 	Given I have an apikey
 	And an apisecret
-	And I have an event id I want details on
-	When I retrieve event details
-	Then I get a response back that has my event
+	And I have a list of event ids I want details on
+	When I retrieve details for the events
+	Then I get a response back that has details for multiple events
 
 Scenario: Specify fields in Events Request
 	Given I have an apikey
@@ -32,9 +31,3 @@ Scenario: Specify fields in Events Request
 	And the response contains the name property
 	And the response contains the hero_image property
 
-Scenario: Specify multiple ids in batch image detail request
-	Given I have an apikey
-	And an apisecret
-	And I have a list of event ids I want details on
-	When I retrieve details for the events
-	Then I get a response back that has details for multiple events

--- a/clientcredentials-image-download.feature
+++ b/clientcredentials-image-download.feature
@@ -1,0 +1,10 @@
+Feature: Image Download with Client Credentials
+  In order to serve image content on my site
+  as a developer consuming the sdk
+  I need to be able to download images
+
+Scenario: Attempt download
+Given I have an apikey
+And an apisecret
+When I request for any image to be downloaded
+Then the url for the image is returned

--- a/clientcredentials-image-search.feature
+++ b/clientcredentials-image-search.feature
@@ -1,4 +1,4 @@
-Feature: Search for Images
+Feature: Search for Images with ClientCredentials
   To create a rockin website with sweet images
   As a developer that wants to expose images to resell
   I'd need to be able to find me some images with minimal effort
@@ -337,21 +337,6 @@ Examples:
 | editorial    | one   |
 | creative     | two   |
 | editorial    | group |
-
-Scenario Outline: Search for images specifying product type
-Given I have an apikey
-And an apisecret
-And a username
-And a password
-When I configure my search for editorial images
-And I specify a <product type> product type
-And I search for dog
-Then I get a response back that has my images
-Examples:
-| product type            |
-| editorialsubscription   |
-| premiumaccess           |
-| easyaccess              |
 
 Scenario: Search for prestige images
 Given I have an apikey

--- a/clientcredentials-images.feature
+++ b/clientcredentials-images.feature
@@ -1,16 +1,7 @@
-Feature: Image Details
+Feature: Image Details with Client credentials
   To create a rockin website with sweet images
   As a developer that wants to get some image details
   I'd need to be able to get detailed metadata about some images
-
-Scenario: Resource Owner Credentials
-	Given I have an apikey
-	And an apisecret
-	And a username
-	And a password
-	And I have an image id I want details on
-	When I retrieve image details
-	Then I get a response back that has my image details
 
 Scenario: Client Credentials
 	Given I have an apikey
@@ -36,13 +27,3 @@ Scenario: Specify multiple ids in batch image detail request
 	And I have a list of image ids I want details on
 	When I retrieve details for the images
 	Then I get a response back that has details for multiple images
-
-Scenario: SDK client throws an exception when an image is not found
-	Given I have an apikey
-	And an api secret
-	And a username
-	And a password
-	And a non-existent image id
-	When I retrieve image details
-	Then an error is returned
-	And the error explains that the image was not found

--- a/clientcredentials-products.feature
+++ b/clientcredentials-products.feature
@@ -1,0 +1,11 @@
+Feature: User Products with Client credentials
+    As a developer using the Getty Images
+    I want to be able to get a list of a user's products
+    So I can display them in my application
+
+Scenario: Retrieve products without specifying user credentials
+    Given I have an apikey
+	And an apisecret
+	When I retrieve products
+    Then I receive a successful response
+    And the products list is empty

--- a/clientcredentials-video-download.feature
+++ b/clientcredentials-video-download.feature
@@ -1,0 +1,10 @@
+Feature: Video Download with Client Credentials
+  In order to serve video content on my site
+  as a developer consuming the sdk
+  I need to be able to download videos
+
+Scenario: Download succeeds
+Given I have an apikey
+And an apisecret
+When I request for any video to be downloaded
+Then the url for the video is returned

--- a/clientcredentials-video-search.feature
+++ b/clientcredentials-video-search.feature
@@ -1,4 +1,4 @@
-Feature: Search for Videos
+Feature: Search for Videos for Client Credentials
 	As a consumer of the SDK
 	I want to search for videos
 	So I can use the videos in my application
@@ -17,18 +17,6 @@ Examples:
 | blended    |
 | creative   |
 | editorial  |
-
-Scenario: SDK client can specify the largest downloads field on video search
-  Given I have an apikey
-  And an api secret
-  And a username
-  And a password
-  And a blended video search
-  And largest_downloads field is specified
-  When the video search is executed
-  Then the status is success
-  And video search results are returned
-  And the largest_download field is returned
 
 Scenario: SDK client can specify age of people filter on video search
   Given I have an apikey
@@ -62,17 +50,6 @@ Scenario: SDK client can specify format filter on video search
   And an api secret
   And a blended video search
   And format filter is specified
-  When the video search is executed
-  Then the status is success
-  And video search results are returned
-
-Scenario: SDK client can specify product type filter on video search
-  Given I have an apikey
-  And an api secret
-  And a username
-  And a password
-  And a blended video search
-  And product type filter is specified
   When the video search is executed
   Then the status is success
   And video search results are returned

--- a/clientcredentials-videos.feature
+++ b/clientcredentials-videos.feature
@@ -1,0 +1,20 @@
+Feature: Video Metadata with Client credentials
+	As a consumer of the SDK
+	I want to get video metadata
+	So I can use the metadata in my application
+
+Scenario: SDK client can get default metadata about a video
+	Given I have an apikey
+	And an api secret
+	And a video id
+	When the video metadata request is executed
+	Then the status is success
+	And the video metadata is returned
+
+Scenario: SDK client can get default metadata about multiple videos
+	Given I have an apikey
+	And an api secret
+	And a list of video ids
+	When the video metadata request is executed
+	Then the status is success
+	And a list of video metadata is returned

--- a/resourceowner-collections.feature
+++ b/resourceowner-collections.feature
@@ -1,15 +1,9 @@
-Feature: Collections
+Feature: Collections with Resource Owner Credentials
   In order to find what I want by collection
   as a developer wanting to use Getty Images assets
   I need to be able to get a list of valid collections
 
-Scenario: Get Collections Client Credentials
-  Given I have an apikey
-    And an apisecret
-  When I retrieve collections
-  Then I recieve an error stating "Your access token does not authorize access to this resource."
-
-Scenario: Get Collections Resource Owner Credentials
+Scenario: Get Collections succeeds
   Given I have an apikey
     And an apisecret
     And a username

--- a/resourceowner-events.feature
+++ b/resourceowner-events.feature
@@ -1,0 +1,13 @@
+Feature: Event Details with Resource Owner Credentials
+  To create a rockin website with sweet images based on events i'm interested in
+  As a developer that wants to get some image details using Resource Owner Credentials
+  I'd need to be able to get events so I can use them to refine my search queries
+
+Scenario: Specify a single event id for event detail request
+	Given I have an apikey
+	And an apisecret
+	And a username
+	And a password
+	And I have an event id I want details on
+	When I retrieve event details
+	Then I get a response back that has my event

--- a/resourceowner-image-download.feature
+++ b/resourceowner-image-download.feature
@@ -1,15 +1,9 @@
-Feature: Image Download
+Feature: Image Download with Resource Owner
   In order to serve image content on my site
   as a developer consuming the sdk
   I need to be able to download images
 
-Scenario: Attempt download with Client Credentials
-Given I have an apikey
-And an apisecret
-When I request for any image to be downloaded
-Then the url for the image is returned
-
-Scenario: Download image with Resource Owner credentials
+Scenario: Download image succeeds
 Given I have an apikey
 And an apisecret
 And a username

--- a/resourceowner-image-search.feature
+++ b/resourceowner-image-search.feature
@@ -1,0 +1,19 @@
+Feature: Search for Images with ResoureOwner
+  To create a rockin website with sweet images
+  As a developer that wants to expose images to resell
+  I'd need to be able to find me some images with minimal effort
+
+Scenario Outline: Search for images specifying product type
+Given I have an apikey
+And an apisecret
+And a username
+And a password
+When I configure my search for editorial images
+And I specify a <product type> product type
+And I search for dog
+Then I get a response back that has my images
+Examples:
+| product type            |
+| editorialsubscription   |
+| premiumaccess           |
+| easyaccess              |

--- a/resourceowner-images.feature
+++ b/resourceowner-images.feature
@@ -1,0 +1,23 @@
+Feature: Image Details with Resource Owner credentials
+  To create a rockin website with sweet images
+  As a developer that wants to get some image details
+  I'd need to be able to get detailed metadata about some images
+
+Scenario: Resource Owner Credentials
+	Given I have an apikey
+	And an apisecret
+	And a username
+	And a password
+	And I have an image id I want details on
+	When I retrieve image details
+	Then I get a response back that has my image details
+
+Scenario: SDK client throws an exception when an image is not found
+	Given I have an apikey
+	And an api secret
+	And a username
+	And a password
+	And a non-existent image id
+	When I retrieve image details
+	Then an error is returned
+	And the error explains that the image was not found

--- a/resourceowner-products.feature
+++ b/resourceowner-products.feature
@@ -1,4 +1,4 @@
-Feature: User Products
+Feature: User Products with Resource Owner credentials
     As a developer using the Getty Images
     I want to be able to get a list of a user's products
     So I can display them in my application
@@ -11,13 +11,6 @@ Scenario: Retrieve a user's products list using their credentials
 	When I retrieve products
 	Then I receive a successful response
 	And the response contains the user's product list
-
-    Scenario: Retrieve products without specifying user credentials
-    Given I have an apikey
-	And an apisecret
-	When I retrieve products
-    Then I receive a successful response
-    And the products list is empty
 
 Scenario: Specify fields in product request
 	Given I have an apikey

--- a/resourceowner-video-download.feature
+++ b/resourceowner-video-download.feature
@@ -1,15 +1,9 @@
-Feature: Video Download
+Feature: Video Download with Resource Owner Credentials
   In order to serve video content on my site
   as a developer consuming the sdk
   I need to be able to download videos
 
-Scenario: Attempt download with Client Credentials
-Given I have an apikey
-And an apisecret
-When I request for any video to be downloaded
-Then the url for the video is returned
-
-Scenario: Download video with Resource Owner credentials
+Scenario: Download video succeeds
 Given I have an apikey
 And an apisecret
 And a username

--- a/resourceowner-video-search.feature
+++ b/resourceowner-video-search.feature
@@ -1,0 +1,16 @@
+Feature: Search for Videos with Resource Owner credentials
+	As a consumer of the SDK
+	I want to search for videos
+	So I can use the videos in my application
+
+Scenario: SDK client can specify the largest downloads field on video search
+  Given I have an apikey
+  And an api secret
+  And a username
+  And a password
+  And a blended video search
+  And largest_downloads field is specified
+  When the video search is executed
+  Then the status is success
+  And video search results are returned
+  And the largest_download field is returned

--- a/resourceowner-videos.feature
+++ b/resourceowner-videos.feature
@@ -1,15 +1,7 @@
-Feature: Video Metadata
+Feature: Video Metadata with Resource Owner Credentials
 	As a consumer of the SDK
 	I want to get video metadata
 	So I can use the metadata in my application
-
-Scenario: SDK client can get default metadata about a video
-	Given I have an apikey
-	And an api secret
-	And a video id
-	When the video metadata request is executed
-	Then the status is success
-	And the video metadata is returned
 
 Scenario: SDK client can specify a field when requesting video metadata
 	Given I have an apikey
@@ -22,14 +14,6 @@ Scenario: SDK client can specify a field when requesting video metadata
 	Then the status is success
 	And the video metadata is returned
 	And the caption field is returned
-
-Scenario: SDK client can get default metadata about multiple videos
-	Given I have an apikey
-	And an api secret
-	And a list of video ids
-	When the video metadata request is executed
-	Then the status is success
-	And a list of video metadata is returned
 
 Scenario: SDK client throws an exception when a video is not found
 	Given I have an apikey


### PR DESCRIPTION
clientcredentials-<featurename>.feature
resourceowner-<featurename>.feature

In some instances there were only scenarios for a single credential type.
I would expect that we will be adding some additional scenario definitions soon, but is not the scope of this work.

The few exceptions to this are authentication.feature, search-pageing.feature. There is no need to delineate credentials types as separate scopes

This is to to make credentials types more apparent as a stronger influence in the results that you can and can not get.
Updated a few scenario names to be more behavior like in wording
Updated Feature descriptions to reflect the scenarios, in some cases the wording appeared to be copy pasted from other features. It's not like I would do anything like that...or something ;)